### PR TITLE
chore: add shizhMSFT to CODEOWNERS and OWNERS.md

### DIFF
--- a/.github/licenserc.yml
+++ b/.github/licenserc.yml
@@ -32,6 +32,7 @@ header:
     - '**/*.json'
     - '**/*.md'
     - 'dist/**'
+    - 'CODEOWNERS'
     - 'LICENSE'
 
   comment: on-failure

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Derived from OWNERS.md
+* @shizhMSFT

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -1,0 +1,4 @@
+# Owners for setup-oras
+
+Owners:
+  - Shiwei Zhang (@shizhMSFT)


### PR DESCRIPTION
Add Shiwei Zhang (@shizhMSFT) to [CODEOWNERS](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) and the `OWNERS.md` file.