### PR TITLE
bump!: update default version to 1.0.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
         os: [macos-latest, windows-latest, ubuntu-latest]
         version:
           - 0.15.1
-          - 0.16.0
+          - 1.0.0
       fail-fast: true
     steps:
     - name: Checkout

--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ steps:
 Install a specific version of the `oras` CLI by specifying the input `version` without the prefix `v`.
 Supported versions can be found at [`oras` releases](https://github.com/oras-project/oras/releases).
 
-For example, install `oras` version `v0.16.0`.
+For example, install `oras` version `v1.0.0`.
 
 ```yaml
 steps:
   - uses: oras-project/setup-oras@main
     with:
-      version: 0.16.0
+      version: 1.0.0
   - run: oras version
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ inputs:
   version:
     description: Version of ORAS CLI to install
     required: false
-    default: 0.16.0
+    default: 1.0.0
 runs:
   using: node16
   main: dist/index.js


### PR DESCRIPTION
The PR updates the default to-be-setup version from 0.16.0 to 1.0.0.