### PR TITLE
build: update major and minor tags update publishing

### DIFF
--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -1,0 +1,61 @@
+# Copyright The ORAS Authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Update major and minor tags
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  update-major-minor-tags:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+      - name: Git config
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+      - name: Tag and push new major and minor versions
+        run: | 
+          VERSION=${{ github.event.release.tag_name }}
+          MAJOR=$(echo ${VERSION} | cut -d '.' -f 1)
+          MINOR=${MAJOR}.$(echo ${VERSION} | cut -d '.' -f 2)
+          if [ -z ${VERSION} ]
+          then
+            echo "released tag cannot be empty"
+            exit 1
+          else
+            echo "released tag is ${VERSION}"
+          fi
+          if [ -z ${MAJOR} ]
+          then
+            echo "major tag cannot be empty"
+            exit 1
+          else
+            echo "major tag is ${MAJOR}"
+          fi
+          if [ -z ${MINOR} ]
+          then
+            echo "minor tag cannot be empty"
+            exit 1
+          else
+            echo "minor tag is ${MINOR}"
+          fi
+          git tag -f ${MAJOR} ${VERSION}
+          git tag -f ${MINOR} ${VERSION}
+          git push origin ${MAJOR} --force
+          git push origin ${MINOR} --force


### PR DESCRIPTION
This PR adds a Github action to update tags automatically after publishing a new release. Validated in [this job run](https://github.com/qweeah/setup-oras/actions/runs/6243246594/job/16948534595).