### PR TITLE
bump: run with node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,5 +22,5 @@ inputs:
     required: false
     default: 1.1.0
 runs:
-  using: node16
+  using: node20
   main: dist/index.js


### PR DESCRIPTION
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: oras-project/setup-oras@v1.1.0. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

Fixes #23
