### PR TITLE
build(ci): make dependabot run weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    labels:
+      - "dependencies"
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
+    labels:
+      - "dependencies"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,12 +19,8 @@ updates:
     # default location of `.github/workflows`
     directory: "/"
     schedule:
-      interval: "daily"
-    labels:
-      - "dependencies"
+      interval: "weekly"
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
-    labels:
-      - "dependencies"
+      interval: "weekly"


### PR DESCRIPTION
It's non-trivial to check-in build changes in npm dependencies bump PRs. Make dependabot run weekly and will manually check in such changes.