### PR TITLE
fix: s390x architecture is not handled

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -6752,7 +6752,7 @@ function mapArch() {
             return 'ppc64le';
         case 'riscv64':
             return 'riscv64';
-        case 's390':
+        case 's390x':
             return 's390x';
         case 'arm':
             return 'armv7';

--- a/src/lib/release.ts
+++ b/src/lib/release.ts
@@ -92,7 +92,7 @@ export function mapArch(): string {
             return 'ppc64le';
         case 'riscv64':
             return 'riscv64';
-        case 's390':
+        case 's390x':
             return 's390x';
         case 'arm':
             return 'armv7';


### PR DESCRIPTION
The project releases s390x binaries (64bit), but not s390 (31bit). Node reports a s390x runner correctly as "s390x", so instllations will fail on this platform.

https://nodejs.org/api/os.html#osarch

Hence the s390 arch case has been changed to the s390x.