### PR TITLE
chore: release v2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "setup-oras",
-  "version": "0.2.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "setup-oras",
-      "version": "0.2.0",
+      "version": "2.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@actions/core": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-oras",
-  "version": "0.2.0",
+  "version": "2.0.0",
   "description": "Set up your GitHub Actions workflow with a specific version of ORAS",
   "scripts": {
     "build": "esbuild src/setup.ts --bundle --platform=node --format=cjs --target=node24 --metafile=dist/meta.json --outfile=dist/index.js && node scripts/generate-licenses.js dist/meta.json dist/licenses.txt && rm dist/meta.json"


### PR DESCRIPTION
Bump \`package.json\` version to \`2.0.0\` in preparation for the v2.0.0 release.

## What's in v2.0.0

- Bump \`@actions/core\` from \`^2.0.3\` to \`^3.0.0\` (#138)
- Bump \`@actions/tool-cache\` from \`^3.0.1\` to \`^4.0.0\` (#137)
- Replace \`@vercel/ncc\` with \`esbuild\` to support ESM-only toolkit packages (#159)
- Add \`scripts/generate-licenses.js\` to regenerate \`dist/licenses.txt\` from bundled packages on every build (#159)
- Pin \`undici\` to \`>=6.24.1\` to address 5 CVEs (#155)