### PR TITLE
feat: auto-cut patch releases when a CLI version is added

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,141 @@
+# Copyright The ORAS Authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Automatically cuts a PATCH release when a new ORAS CLI version is added to
+# src/lib/data/releases.json on main (e.g. via the "Update releases.json"
+# workflow). Minor and major releases are always cut by hand — see
+# RELEASING.md.
+#
+# This job creates the release AND moves the floating vX / vX.Y tags itself,
+# rather than relying on update-version.yml. A release created with the default
+# GITHUB_TOKEN does not emit a `release: published` event (GitHub suppresses it
+# to prevent workflow recursion), so update-version.yml would never fire.
+
+name: Auto release
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'src/lib/data/releases.json'
+  workflow_dispatch:
+
+# Serialize releases so two quick pushes can't race to tag the same line.
+concurrency:
+  group: auto-release
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  auto-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Detect newly added ORAS CLI versions
+        id: detect
+        run: |
+          set -euo pipefail
+          if ! git rev-parse -q --verify HEAD^ >/dev/null; then
+            echo "No parent commit; nothing to diff." >&2
+            echo "added=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git show HEAD^:src/lib/data/releases.json > /tmp/releases-old.json
+          ADDED=$(jq -r -s '(.[1] | keys) - (.[0] | keys) | join(", ")' \
+            /tmp/releases-old.json src/lib/data/releases.json)
+          echo "added=${ADDED}" >> "$GITHUB_OUTPUT"
+          if [ -z "${ADDED}" ]; then
+            echo "No new ORAS CLI version keys added; skipping release." >&2
+          else
+            echo "New ORAS CLI version(s): ${ADDED}" >&2
+          fi
+
+      - name: Compute next patch version
+        id: version
+        if: steps.detect.outputs.added != ''
+        run: |
+          set -euo pipefail
+          LATEST=$(git tag -l 'v*.*.*' | sort -V | tail -1)
+          if [ -z "${LATEST}" ]; then
+            echo "No existing vX.Y.Z tag found; refusing to guess a version." >&2
+            exit 1
+          fi
+          V=${LATEST#v}
+          MAJOR=${V%%.*}
+          REST=${V#*.}
+          MINOR=${REST%%.*}
+          PATCH=${REST#*.}
+          NEXT="v${MAJOR}.${MINOR}.$((PATCH + 1))"
+          if git rev-parse -q --verify "refs/tags/${NEXT}" >/dev/null; then
+            echo "Tag ${NEXT} already exists; nothing to do." >&2
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          {
+            echo "latest=${LATEST}"
+            echo "next=${NEXT}"
+            echo "major_tag=v${MAJOR}"
+            echo "minor_tag=v${MAJOR}.${MINOR}"
+            echo "skip=false"
+          } >> "$GITHUB_OUTPUT"
+          echo "Releasing ${NEXT} (previous: ${LATEST})" >&2
+
+      - name: Create release
+        if: steps.detect.outputs.added != '' && steps.version.outputs.skip == 'false'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEXT: ${{ steps.version.outputs.next }}
+          LATEST: ${{ steps.version.outputs.latest }}
+          ADDED: ${{ steps.detect.outputs.added }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          NOTES=$(cat <<EOF
+          ## Highlights
+
+          - Support ORAS CLI version(s) \`${ADDED}\`
+
+          Automated patch release cut by \`.github/workflows/auto-release.yml\`
+          when new ORAS CLI version(s) landed in \`src/lib/data/releases.json\`.
+
+          **Full Changelog**: https://github.com/${REPO}/compare/${LATEST}...${NEXT}
+          EOF
+          )
+          gh release create "${NEXT}" \
+            --repo "${REPO}" \
+            --target "${GITHUB_SHA}" \
+            --title "${NEXT}" \
+            --notes "${NOTES}"
+
+      - name: Move floating major and minor tags
+        if: steps.detect.outputs.added != '' && steps.version.outputs.skip == 'false'
+        env:
+          MAJOR_TAG: ${{ steps.version.outputs.major_tag }}
+          MINOR_TAG: ${{ steps.version.outputs.minor_tag }}
+        run: |
+          set -euo pipefail
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git tag -f "${MAJOR_TAG}" "${GITHUB_SHA}"
+          git tag -f "${MINOR_TAG}" "${GITHUB_SHA}"
+          git push origin "${MAJOR_TAG}" "${MINOR_TAG}" --force

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,133 @@
+<!--
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Releasing setup-oras
+
+This document describes how to cut a release of the `setup-oras` GitHub
+Action.
+
+## Two versions, decoupled
+
+There are two independent version streams. Keep them separate in your head:
+
+- **The action's version** — the `vX.Y.Z` git tags and GitHub Releases of
+  *this repository* (e.g. `v2.0.1`). This is what consumers pin with
+  `uses: oras-project/setup-oras@v2`.
+- **The ORAS CLI versions** — the keys in
+  [`src/lib/data/releases.json`](src/lib/data/releases.json) (e.g. `1.3.3`).
+  These are the CLI versions the action knows how to install. Adding a CLI
+  version does **not** change the action's version by itself.
+
+## When to bump which part
+
+Follow [semver](https://semver.org/) for the **action's** version:
+
+| Change to the action | Version bump | Example |
+| --- | --- | --- |
+| A new ORAS CLI version was added to `releases.json`, or any other backward-compatible fix | **patch** | `v2.0.1` → `v2.0.2` |
+| A backward-compatible feature was added to the action | **minor** | `v2.0.x` → `v2.1.0` |
+| A breaking change to the action (e.g. Node runtime migration, dropping older runners, changed inputs/outputs) | **major** | `v1.2.4` → `v2.0.0` |
+
+Historically, adding ORAS CLI support ships as a **patch** release on the
+current major line. Minor and major bumps are reserved for changes to the
+action itself and are always cut by hand — never automate them.
+
+> The `v1` line is frozen (Node 20 runtime). All new CLI support lands on the
+> current `v2`+ line.
+
+## How a CLI version gets added
+
+The [`Update releases.json`](.github/workflows/update-releases.yml) workflow
+runs daily (and on demand via *workflow_dispatch*). It detects new upstream
+ORAS releases and opens an automated PR that adds them to `releases.json` and
+rebuilds `dist/`. Review it against the checklist in the PR body (verify
+checksums against https://github.com/oras-project/oras/releases; confirm
+`check-dist` is green) and merge it.
+
+Merging that PR **does not** release the action. It only lands the new CLI
+support on `main`. You still need to cut a release for consumers pinned to a
+floating tag (`@v2`, `@v2.0`) to pick it up.
+
+## Cutting a release
+
+### 1. Confirm `main` is green
+
+The tip of `main` you are about to tag must have passing **Check dist/**,
+**Tests**, and **License Checker** runs.
+
+```bash
+gh run list --repo oras-project/setup-oras --branch main -L 5
+```
+
+### 2. Pick the next version
+
+Bump the appropriate part per the table above. For a new-CLI-version release,
+patch-bump the latest tag:
+
+```bash
+gh release list --repo oras-project/setup-oras -L 1   # find the latest, e.g. v2.0.1
+```
+
+### 3. Publish the GitHub Release
+
+Create an annotated tag + release off `main`. Auto-generate notes, then edit
+in a short **Highlights** section (the ORAS CLI versions now supported)
+matching the style of previous releases.
+
+```bash
+gh release create v2.0.2 \
+  --repo oras-project/setup-oras \
+  --target main \
+  --title v2.0.2 \
+  --generate-notes
+```
+
+### 4. Let the floating tags move
+
+Publishing the release fires the
+[`Update major and minor tags`](.github/workflows/update-version.yml)
+workflow (`on: release: published`), which force-moves the **`vX`** and
+**`vX.Y`** tags to the released commit.
+
+```bash
+gh run list --repo oras-project/setup-oras --workflow update-version.yml -L 3
+gh api repos/oras-project/setup-oras/git/ref/tags/v2   -q '.object.sha'
+gh api repos/oras-project/setup-oras/git/ref/tags/v2.0 -q '.object.sha'
+```
+
+Both should now equal the released commit. Consumers on `@v2` / `@v2.0` now
+resolve to the new version.
+
+> If a tag protection ruleset blocks the `github-actions` bot from
+> force-pushing `vX` / `vX.Y`, the release will publish but the floating tags
+> will not move. Check the `update-version.yml` run, resolve the ruleset, and
+> re-run the workflow.
+
+## Automating patch releases (optional)
+
+New-CLI-version releases are pure patch bumps and can be fully automated. A
+`push`-to-`main` workflow can detect that `src/lib/data/releases.json` gained
+a new version key, compute the next patch tag, and cut the release. Two things
+to get right:
+
+- **Only new CLI keys trigger it.** Diff `releases.json` against the parent
+  commit; skip dependency bumps and formatting changes.
+- **Beware `GITHUB_TOKEN` recursion.** A release created with the default
+  `GITHUB_TOKEN` does **not** fire the `release: published` event, so
+  `update-version.yml` won't run. Either create the release with a PAT / App
+  token, or have the auto-release job move the `vX` / `vX.Y` tags itself
+  instead of relying on the release event.
+
+Minor and major releases stay manual.


### PR DESCRIPTION
## What

Adds a workflow that automatically cuts a **patch** release when a new ORAS
CLI version lands in `src/lib/data/releases.json` on `main`, plus a
`RELEASING.md` documenting the release process.

Follows on from the manual `v2.0.1` release, which shipped ORAS CLI 1.3.2 and
1.3.3 support. That release was cut entirely by hand; this automates the common
case so a new CLI version releases itself.

## How it works

`.github/workflows/auto-release.yml` triggers on `push` to `main` filtered to
`src/lib/data/releases.json` (e.g. after the `Update releases.json` PR merges):

1. **Detect** — diffs `releases.json` against `HEAD^` and extracts newly added
   version keys. If none were added (dependency bumps, formatting, checksum
   edits), the job ends without releasing.
2. **Version** — finds the latest `vX.Y.Z` tag and patch-bumps it
   (`v2.0.1` → `v2.0.2`). Idempotent: skips if the target tag already exists.
3. **Release** — `gh release create` off the pushed commit with a Highlights
   body naming the added CLI version(s).
4. **Move tags** — force-moves `vX` and `vX.Y` to the release commit,
   **in the same job**.

### Why the tag move is in-job

A release created with the default `GITHUB_TOKEN` does not emit a
`release: published` event (GitHub suppresses it to prevent workflow
recursion), so the existing `update-version.yml` would never fire. Doing the
major/minor tag move directly in this job avoids needing a PAT. The workflow
only pushes tag refs, so it cannot self-trigger.

## Scope / guardrails

- **Patch-only.** Minor and major releases (breaking action changes, e.g. the
  Node runtime migration in v2.0.0) stay manual — see `RELEASING.md`.
- `concurrency: auto-release` serializes releases.
- `workflow_dispatch` is included for manual testing.
- Only elevated permission is `contents: write`.

## Note for reviewers

The `github-actions` bot must be permitted to force-push `vX` / `vX.Y` under
any tag protection ruleset. `update-version.yml` already does this today, so
the same permissions apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)